### PR TITLE
Do not pass GZIP=-n

### DIFF
--- a/tardist
+++ b/tardist
@@ -39,7 +39,7 @@ mkdir  $distdir
 
 cp -p $(<MANIFEST) $distdir/
 
-GZIP=-n tar --owner=0 --group=0 --numeric-owner "${tar_mtime[@]}" -cvzf \
+tar --owner=0 --group=0 --numeric-owner "${tar_mtime[@]}" -cvzf \
     $tarball $distdir
 chmod 0444 $tarball
 


### PR DESCRIPTION
In gzip 1.9, setting envvar GZIP generates a "deprecated" warning.
In gzip 1.10, -n is the default anyway.