### PR TITLE
Change license from X Consortium to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 1994, 2017 Eduardo Santiago
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+

--- a/xlbiff.c
+++ b/xlbiff.c
@@ -14,18 +14,7 @@
 |*	Last Updated:	16 May 2017
 |*
 |*    Copyright 1994, 2017 Eduardo Santiago
-|*
-|*    The X Consortium, and any party obtaining a copy of these files from
-|*    the X Consortium, directly or indirectly, is granted, free of charge, a
-|*    full and unrestricted irrevocable, world-wide, paid up, royalty-free,
-|*    nonexclusive right and license to deal in this software and
-|*    documentation files (the "Software"), including without limitation the
-|*    rights to use, copy, modify, merge, publish, distribute, sublicense,
-|*    and/or sell copies of the Software, and to permit persons who receive
-|*    copies from any such party to do so.  This license includes without
-|*    limitation a license to do the foregoing actions under any patents of
-|*    the party supplying this software to the X Consortium.
-|*
+|*    SPDX-License-Identifier: MIT
 \*/
 
 #include <X11/Intrinsic.h>


### PR DESCRIPTION
Move license text into new file "LICENSE".

Update license text from old "any party obtaining a copy of these
files from the X Consortium ... is granted" to general MIT license.