### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+xlbiff (4.5.2-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on debhelper.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 09 Sep 2021 13:22:54 -0000
+
 xlbiff (4.5.2-1) unstable; urgency=low
 
   * Popup problem fixed where a screen size change would move the

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Vcs-Git: https://github.com/edsantiago/xlbiff.git/
 Vcs-Browser: https://github.com/edsantiago/xlbiff
 Homepage: http://www.edsantiago.com/xlbiff/
 Build-Depends:
- debhelper (>= 10),
+ debhelper,
  pkg-config,
  libxaw7-dev,
  libxt-dev,


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/xlbiff/7ba340e4-4006-4252-93eb-e440079f23b5.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/23/bd8f273546b1e24c8da49a2cdb3f5679de8770.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/af/c0ff47459790cedfe00852dca36a65ea5c5ecb.debug

No differences were encountered between the control files of package \*\*xlbiff\*\*
### Control files of package xlbiff-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-afc0ff47459790cedfe00852dca36a65ea5c5ecb-] {+23bd8f273546b1e24c8da49a2cdb3f5679de8770+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7ba340e4-4006-4252-93eb-e440079f23b5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7ba340e4-4006-4252-93eb-e440079f23b5/diffoscope)).
